### PR TITLE
Fix creating attachments

### DIFF
--- a/Custom/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
+++ b/Custom/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
@@ -1696,6 +1696,7 @@ sub _TicketCreate {
 
             for my $Attachment ( @{$AttachmentList} ) {
                 my $Result = $Self->CreateAttachment(
+                    TicketID   => $TicketID,
                     Attachment => $Attachment,
                     ArticleID  => $ArticleID,
                     UserID     => $Param{UserID}

--- a/Custom/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Custom/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -2284,6 +2284,7 @@ sub _TicketUpdate {
 
                 for my $Attachment ( @{$AttachmentList} ) {
                     my $Result = $Self->CreateAttachment(
+                        TicketID   => $TicketID,
                         Attachment => $Attachment,
                         ArticleID  => $ArticleID,
                         UserID     => $Param{UserID}

--- a/Znuny4OTRS-GIArticleSend.sopm
+++ b/Znuny4OTRS-GIArticleSend.sopm
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <otrs_package version="1.0">
     <Name>Znuny4OTRS-GIArticleSend</Name>
-    <Version>6.0.1</Version>
+    <Version>6.0.3</Version>
+    <ChangeLog Version="6.0.3" Date="2018-01-04 14:30:54 +0100">Fix Attachment creation for OTRS 6.0.3 and above.</ChangeLog>
     <ChangeLog Version="6.0.1" Date="2017-11-15 15:11:54 +0100">Initial release 6.0.x.</ChangeLog>
     <ChangeLog Version="5.0.4" Date="2016-11-24 09:13:19 +0100">added optional paramater for signing/encryption with S/MIME and PGP</ChangeLog>
     <ChangeLog Version="5.0.3" Date="2016-10-28 17:23:44 +0200">Added content type handling for ArticleSend feature, pull request #1, many thanks to @BlangTech.</ChangeLog>


### PR DESCRIPTION
Hi guys,

at last we had a look at it in work with @binao since it is way too important to our workflow here...

This is the fix, tested on our docker test (https://github.com/ucetnictvi-on-line/otrs-for-docker) and also then on production (build and everything)

Pleaso do merge, we would be really thankfull if we could install from your repo not from .opm file

PS. for quick test I am attaching our built .opm:
[Znuny4OTRS-GIArticleSend-6.0.3.opm.zip](https://github.com/znuny/Znuny4OTRS-GIArticleSend/files/1603500/Znuny4OTRS-GIArticleSend-6.0.3.opm.zip)

